### PR TITLE
Vichan: Fix up URL parsing

### DIFF
--- a/src/nya/miku/wishmaster/chans/vichan/VichanModule.java
+++ b/src/nya/miku/wishmaster/chans/vichan/VichanModule.java
@@ -148,4 +148,10 @@ public class VichanModule extends AbstractVichanModule {
     public UrlPageModel parseUrl(String url) throws IllegalArgumentException {
         return super.parseUrl(url.replaceAll("-\\w+.*html", ".html"));
     }
+
+    @Override
+    public String fixRelativeUrl(String url) {
+        if (url.startsWith("?/")) url = url.substring(1);
+        return super.fixRelativeUrl(url);
+    }
 }


### PR DESCRIPTION
It looks like for some reason it adds "/?/"
to the link causing the >>post_ID to be treated
as external link instead of quote link.
Replacing "/?/" with "/" fixes that issue.
