### PR TITLE
Fix file path of deduplicated images for 8ch

### DIFF
--- a/src/nya/miku/wishmaster/api/AbstractVichanModule.java
+++ b/src/nya/miku/wishmaster/api/AbstractVichanModule.java
@@ -276,10 +276,12 @@ public abstract class AbstractVichanModule extends AbstractWakabaModule {
             attachment.originalName = object.optString("filename", "") + ext;
             attachment.isSpoiler = isSpoiler;
             String tim = object.optString("tim", "");
+            String thumbLocation = tim.length() == 64 ? "/file_store/thumb/" : "/" + boardName + "/thumb/";
+            String fileLocation = tim.length() == 64 ? "/file_store/" : "/" + boardName + "/src/";
             if (tim.length() > 0) {
                 attachment.thumbnail = isSpoiler || attachment.type == AttachmentModel.TYPE_AUDIO ? null :
-                    ("/" + boardName + "/thumb/" + tim + ".jpg");
-                attachment.path = "/" + boardName + "/src/" + tim + ext;
+                    (thumbLocation + tim + ".jpg");
+                attachment.path = fileLocation + tim + ext;
                 return attachment;
             }
         }


### PR DESCRIPTION
Checks length of `tim` parameter to determine location of image and image thumbnail
